### PR TITLE
Use fullmatch for regex matching instead of search

### DIFF
--- a/src/connection-service/connection-flask.py
+++ b/src/connection-service/connection-flask.py
@@ -237,7 +237,7 @@ def get_connection(part):
       store=partitions[part]
       matched=[]
       for uid,con in store.items():
-        if regex.search(uid) and con.data_type==dt and now-con.time<entry_ttl:
+        if regex.fullmatch(uid) and con.data_type==dt and now-con.time<entry_ttl:
           #print (f"Found matching entry {uid} {con=}")
           #result.append('{'
           #              f'"uid":"{uid}",'


### PR DESCRIPTION
Partitions with >10 dataflow apps were failing (see https://github.com/DUNE-DAQ/iomanager/issues/71). This was due to the connectivity server only comparing the beginning of a string use `re.match` and matching both '1' and '10'... Changed to using `re.fullmatch`.