### PR TITLE
Use new tag for connectivity server in Dockerfile

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -6,7 +6,7 @@ RUN yum clean all \
  && yum -y install python3-pip python3-pip-wheel python3-devel git \
  && yum clean all
 
-RUN git clone --depth 1 -b v1.0.0 https://github.com/DUNE-DAQ/connectivityserver.git
+RUN git clone --depth 1 -b v1.1.1 https://github.com/DUNE-DAQ/connectivityserver.git
 RUN pip3 install /connectivityserver
 
 COPY --chmod=755 entrypoint.sh /


### PR DESCRIPTION
The Dockerfile clones a specific tag of this package. Update the Dockerfile to use a new tag v1.1.1 which will be made after this merge!