### PR TITLE
Modified connection-flask.py so that each print statement gets flushe…

### DIFF
--- a/src/connection-service/connection-flask.py
+++ b/src/connection-service/connection-flask.py
@@ -14,6 +14,10 @@ from datetime import datetime, timedelta
 from collections import namedtuple
 from flask import Flask, request, abort, make_response
 
+# 30-Jan-2025, KAB: tweak the print() statement default behavior so that it always flushes the output.
+# Without this, debug messages from this code appear in the ConnSvc log file at somewhat random times.
+import functools
+print = functools.partial(print, flush=True)
 
 partitions={}
 partlock=Lock()
@@ -153,6 +157,9 @@ def publish():
     #print (f"{connection=}")
     if 'uid' in  connection and 'uri' in connection:
       uid=connection['uid']
+      if debug_level>1:
+        now=datetime.now()
+        print(f"[{now}] Publish uid={uid}")
       store[uid]=Connection(uri=connection['uri'],
                             connection_type=connection['connection_type'],
                             data_type=connection['data_type'],


### PR DESCRIPTION
…d immediatedly (this helps when debugging), and added a printout of each published UID.

In my experience, the output from the debug print statements (without my flush=True addition) can be *very* confusing because they seem to appear at somewhat random places in the ConnSvc log file.

I can provide instructions for how to test this, if that is useful.
