### PR TITLE
Make filesystem readonly to the container

### DIFF
--- a/deploy/connectivityserver.yaml
+++ b/deploy/connectivityserver.yaml
@@ -57,6 +57,7 @@ spec:
           runAsUser: 10000
           runAsGroup: 10000
           runAsNonRoot: true
+          readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           seccompProfile:
             type: RuntimeDefault


### PR DESCRIPTION
This should probably be tested in the wild, but security scanners are flagging it as important