### PR TITLE
Since we aren't using the k8s api, don't mount credentials

### DIFF
--- a/deploy/connectivityserver.yaml
+++ b/deploy/connectivityserver.yaml
@@ -38,6 +38,7 @@ spec:
             - matchExpressions:
               - key: node-role.kubernetes.io/worker
                 operator: Exists
+      automountServiceAccountToken: false
       containers:
       - image: ghcr.io/dune-daq/connectivityserver:v1.1.1
         name: connectionservice


### PR DESCRIPTION
This should be validated on a test instance before merge, but should cause no issues