### PR TITLE
Switch to AL10 base container

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/almalinux:9
+FROM docker.io/almalinux:10
 
 EXPOSE 5000
 ARG VERSION=develop

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,7 @@ requires-python = ">=3.6"
 urls = { "homepage" = "https://github.com/DUNE-DAQ/connectivityserver" }
 dependencies = [
        "Flask",
-       "gevent",
-       "gunicorn",
-       "Werkzeug"
+       "gunicorn[gevent]",
 ]
 
 [tool.setuptools]
@@ -24,7 +22,6 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 "*" = ["*"]
-
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
# Description
Switch to AL10 as the container base layer.

This also moves the dependency management to use gunicorn's optional dependency target to ensure gevent and Werkzeug are versions known to work with gunicorn.


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`daqsystemtest_integtest_bundle.sh`)
- [x] Python tests pass if applicable (e.g. `python -m pytest`)
- [x] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

