### PR TITLE
Format Connection Details clearly

### DIFF
--- a/src/connectivityserver/connectionflask.py
+++ b/src/connectivityserver/connectionflask.py
@@ -72,13 +72,35 @@ def dump():
     dstream.write("</table>")
     for p in partitions:
       store=partitions[p]
-      dstream.write(f'<h2>Partition {p}</h2><p>')
+      dstream.write(f'<h2>Partition {p}</h2>')
+      dstream.write(f'<table style="border: 1px solid black">'
+                    f'<tr style="background: #e0e0e0">'
+                    f'<th{pad} rowspan="2">Title</th>'
+                    f'<th{pad} colspan="5">Connection</th>'
+                    f'</tr>'
+                    f'<tr style="background: #e0e0e0">'
+                    f'<th{pad}>uri</th>'
+                    f'<th{pad}>data_type</th>'
+                    f'<th{pad}>capacity</th>'
+                    f'<th{pad}>connection_type</th>'
+                    f'<th{pad}>time</th>'
+                    f'</tr>')
       for k,v in store.items():
         if now-v.time<entry_ttl:
-          dstream.write(f'{k}: {v}</br>')
+          dstream.write(f'<tr><td{pad}>{k}</td>'
+                        f'<td{pad}>{v.uri}</td>'
+                        f'<td{pad}>{v.data_type}</td>'
+                        f'<td{pad}>{v.capacity}</td>'
+                        f'<td{pad}>{v.connection_type}</td>'
+                        f'<td{pad}>{v.time}</td></tr>')
         else:
-          dstream.write(f'<strike>{k}: {v}</strike></br>')
-      dstream.write("</p>")
+          dstream.write(f'<tr><td{pad}><strike>{k}</strike></td>'
+                        f'<td{pad}><strike>{v.uri}</strike></td>'
+                        f'<td{pad}><strike>{v.data_type}</strike></td>'
+                        f'<td{pad}><strike>{v.capacity}</strike></td>'
+                        f'<td{pad}><strike>{v.connection_type}</strike></td>'
+                        f'<td{pad}><strike>{v.time}</strike></td></tr>')
+      dstream.write("</table>")
   else:
     dstream.write("None</p>")
   dstream.write("<hr><h2>Server statistics</h2>")

--- a/src/connectivityserver/connectionflask.py
+++ b/src/connectivityserver/connectionflask.py
@@ -70,9 +70,10 @@ def dump():
       dstream.write(f'<tr><td{pad}>{p}'
                     f'</td><td{pad}>{len(partitions[p])}</td></tr>')
     dstream.write("</table>")
+    dstream.write(f'<h2>Partitions</h2>')
     for p in partitions:
       store=partitions[p]
-      dstream.write(f'<h2>Partition {p}</h2>')
+      dstream.write(f'<h3>{p}</h3>')
       dstream.write(f'<table style="border: 1px solid black">'
                     f'<tr style="background: #e0e0e0">'
                     f'<th{pad} rowspan="2">Title</th>'

--- a/src/connectivityserver/connectionflask.py
+++ b/src/connectivityserver/connectionflask.py
@@ -76,7 +76,7 @@ def dump():
       dstream.write(f'<h3>{p}</h3>')
       dstream.write(f'<table style="border: 1px solid black">'
                     f'<tr style="background: #e0e0e0">'
-                    f'<th{pad} rowspan="2">Title</th>'
+                    f'<th{pad} rowspan="2">Name</th>'
                     f'<th{pad} colspan="5">Connection</th>'
                     f'</tr>'
                     f'<tr style="background: #e0e0e0">'

--- a/src/connectivityserver/connectionflask.py
+++ b/src/connectivityserver/connectionflask.py
@@ -85,21 +85,15 @@ def dump():
                     f'<th{pad}>connection_type</th>'
                     f'<th{pad}>time</th>'
                     f'</tr>')
+      format_cell=lambda value,strike: f'<strike>{value}</strike>' if strike else f'{value}'
       for k,v in store.items():
-        if now-v.time<entry_ttl:
-          dstream.write(f'<tr><td{pad}>{k}</td>'
-                        f'<td{pad}>{v.uri}</td>'
-                        f'<td{pad}>{v.data_type}</td>'
-                        f'<td{pad}>{v.capacity}</td>'
-                        f'<td{pad}>{v.connection_type}</td>'
-                        f'<td{pad}>{v.time}</td></tr>')
-        else:
-          dstream.write(f'<tr><td{pad}><strike>{k}</strike></td>'
-                        f'<td{pad}><strike>{v.uri}</strike></td>'
-                        f'<td{pad}><strike>{v.data_type}</strike></td>'
-                        f'<td{pad}><strike>{v.capacity}</strike></td>'
-                        f'<td{pad}><strike>{v.connection_type}</strike></td>'
-                        f'<td{pad}><strike>{v.time}</strike></td></tr>')
+        expired = now-v.time >= entry_ttl
+        dstream.write(f'<tr><td{pad}>{format_cell(k,expired)}</td>'
+                      f'<td{pad}>{format_cell(v.uri,expired)}</td>'
+                      f'<td{pad}>{format_cell(v.data_type,expired)}</td>'
+                      f'<td{pad}>{format_cell(v.capacity,expired)}</td>'
+                      f'<td{pad}>{format_cell(v.connection_type,expired)}</td>'
+                      f'<td{pad}>{format_cell(v.time,expired)}</td></tr>')
       dstream.write("</table>")
   else:
     dstream.write("None</p>")

--- a/src/connectivityserver/connectionflask.py
+++ b/src/connectivityserver/connectionflask.py
@@ -85,7 +85,7 @@ def dump():
                     f'<th{pad}>connection_type</th>'
                     f'<th{pad}>time</th>'
                     f'</tr>')
-      format_cell=lambda value,strike: f'<strike>{value}</strike>' if strike else f'{value}'
+      format_cell=lambda value,strike: f'<span style="color: red;">{value}</span>' if strike else f'{value}'
       for k,v in store.items():
         expired = now-v.time >= entry_ttl
         dstream.write(f'<tr><td{pad}>{format_cell(k,expired)}</td>'


### PR DESCRIPTION
# Description

Fixes #30 

Formats the connectivity service output into a nice table. 



Before:
<img width="1360" height="599" alt="Screenshot 2026-04-27 at 13 23 38" src="https://github.com/user-attachments/assets/690ca255-eea4-42ab-8d2d-aad4dcafad4c" />



After:
<img width="795" height="433" alt="Screenshot 2026-04-27 at 16 28 53" src="https://github.com/user-attachments/assets/cc145788-af3e-4a19-9d4d-695aa0eaa3a4" />

After, with expired sessions:
For this image please just focus on the red text and not the titles

<img width="1157" height="355" alt="Screenshot 2026-04-27 at 13 51 32" src="https://github.com/user-attachments/assets/af25be9f-18a3-4758-a54b-90aa6c35ed03" />



## Review instructions 
Check out this branch on develop (this was tested on the nightly of 2026-04-23)

Run a simple instance of drunc, eg `drunc-unified-shell ssh-standalone config/daqsystemtest/example-configs.data.xml local-1x1-config emir-test boot start-shell`

View the connectivity service on the browser 

- You'll have to find the URI of the connectivity service. Check the output of eg. the root controller: `Connectivity server localhost:30005 is enabled`
- If its on the np04 machines, dont forget to enable the proxys
- See the new table and check its all good 






## Type of change
- [x] New feature or enhancement (non-breaking change which adds functionality)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [x] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)


## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [x] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [x] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

