### PR TITLE
Rename partition to session

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,7 @@ server to serve connection information to DAQ applications.
     http://connection-flask.connections:5000/publish
 ```
 
-### /getconnection/<partition> 
+### /getconnection/<session> 
 This uri returns a list of connections matching the 'uid_regex' and
 'data_type' specified in the JSON encoded request.
 
@@ -53,9 +53,9 @@ curl -d '{"uid_regex":"DRO.*","data_type":"TPSet"}' \
 This uri should be used to remove published connections. The request should be JSON encoded with the keys "partition" and "connections" with the latter being an array of "connection_id" and "data_type" values.
 
 
-### /retract-partition
+### /retract-session
 This uri should be used to remove all published connections from the
-given partition. The request should be JSON encoded with one field "partition" naming the partition to be retracted.
+given session. The request should be JSON encoded with one field "session" naming the session to be retracted.
 
 ## Running the server locally from the command line
  The server is intended to be run under the Gunicorn web server.

--- a/src/connectivityserver/connectionflask.py
+++ b/src/connectivityserver/connectionflask.py
@@ -212,8 +212,8 @@ def publish():
   partlock.release()
   return 'OK'
 
-@app.route("/retract-partition",methods=['POST'])
-def retract_partition():
+@app.route("/retract-session",methods=['POST'])
+def retract_session():
   if len(request.data) == 0:
     abort(400)
 
@@ -232,6 +232,16 @@ def retract_partition():
     return 'OK'
   partlock.release()
   abort(404)
+
+
+@app.route("/retract-partition",methods=['POST'])
+def retract_partition():
+  """
+  For backwards compatibility.
+  Delete this when the partition word is completely retired
+  """
+  log.warning("retract-partition depreciated. Please use retract-session.")
+  retract_session()
 
 @app.route("/retract",methods=['POST'])
 def retract():

--- a/src/connectivityserver/connectionflask.py
+++ b/src/connectivityserver/connectionflask.py
@@ -27,6 +27,22 @@ if 'CONNECTION_FLASK_DEBUG' in os.environ:
 else:
   debug_level=1
 
+
+def get_sesh(js):
+  has_session = 'session' in js
+  has_partition = 'partition' in js
+
+  if has_session and has_partition:
+    raise ValueError("Both 'session' and 'partition' were provided")
+
+  if has_session:
+    return js['session']
+
+  if has_partition:
+    return js['partition']
+
+  raise ValueError("No session (partition) provided")
+
 def convert_log_level(log_level):
   if log_level == 0:
     return logging.WARNING
@@ -161,7 +177,10 @@ def publish():
   js=json.loads(request.data)
 
   log.debug(f"{js=}")
-  sesh=js['partition']
+  try:
+    sesh = get_sesh(js)
+  except ValueError:
+    abort(400)
 
   log.info(
     f"{len(js['connections'])} connections in session {sesh} from {request.remote_addr} uri={js['connections'][0]['uri']}..."
@@ -220,10 +239,11 @@ def retract_session():
   js=json.loads(request.data)
   log.debug(f"request=[{js}]")
 
-  if 'partition' not in js:
+  try:
+    sesh = get_sesh(js)
+  except ValueError:
     abort(400)
 
-  sesh=js['partition']
   seshlock.acquire()
 
   if sesh in sessions:
@@ -250,7 +270,11 @@ def retract():
 
   js=json.loads(request.data)
   good=True
-  sesh=js['partition']
+  try:
+    sesh = get_sesh(js)
+  except ValueError:
+    abort(400)
+
   seshlock.acquire()
   if sesh not in sessions:
     seshlock.release()

--- a/src/connectivityserver/connectionflask.py
+++ b/src/connectivityserver/connectionflask.py
@@ -19,8 +19,8 @@ from flask import Flask, abort, make_response, request
 # Some functions exit with an abort(NNN) instead of return so don't complain!
 #ruff: noqa RET503
 
-partitions={}
-partlock=Lock()
+sessions={}
+seshlock=Lock()
 
 if 'CONNECTION_FLASK_DEBUG' in os.environ:
   debug_level=int(os.environ['CONNECTION_FLASK_DEBUG'])
@@ -50,7 +50,7 @@ npublishes=0
 nlookups=0
 lookup_time=timedelta(0)
 publish_time=timedelta()
-maxpartitions=0
+maxsessions=0
 maxentries={}
 
 app=Flask(__name__)
@@ -60,19 +60,19 @@ def dump():
   now=datetime.now()
   dstream=StringIO()
   dstream.write('<h1>Dump of configuration dictionary</h1>')
-  dstream.write("<h2>Active partitions</h2><p>")
-  if len(partitions)>0:
+  dstream.write("<h2>Active sessions</h2><p>")
+  if len(sessions)>0:
     pad=' style="padding-left: 1em;padding-right: 1em"'
     dstream.write(f'<table style="border: 1px solid black">'
-                  f'<tr style="background: #e0e0e0"><th{pad}>Partition</th>'
+                  f'<tr style="background: #e0e0e0"><th{pad}>Session</th>'
                   f'<th{pad}>Entries</th></tr>')
-    for p in partitions:
+    for p in sessions:
       dstream.write(f'<tr><td{pad}>{p}'
-                    f'</td><td{pad}>{len(partitions[p])}</td></tr>')
+                    f'</td><td{pad}>{len(sessions[p])}</td></tr>')
     dstream.write("</table>")
-    dstream.write(f'<h2>Partitions</h2>')
-    for p in partitions:
-      store=partitions[p]
+    dstream.write(f'<h2>Sessions</h2>')
+    for p in sessions:
+      store=sessions[p]
       dstream.write(f'<h3>{p}</h3>')
       dstream.write(f'<table style="border: 1px solid black">'
                     f'<tr style="background: #e0e0e0">'
@@ -117,9 +117,9 @@ def stats_to_html(dstream):
     avg_lookup=timedelta()
   dstream.write(f"<p>{nlookups} calls to lookup in total time {lookup_time} "
                 f"(average {avg_lookup.microseconds} &micro;s per call)</p>")
-  dstream.write(f"<p>Maximum number of partitions active = {maxpartitions}</p>")
-  for part in maxentries:
-    dstream.write(f"<p>Maximum entries in partition {part} = {maxentries[part]}</p>")
+  dstream.write(f"<p>Maximum number of sessions active = {maxsessions}</p>")
+  for sesh in maxentries:
+    dstream.write(f"<p>Maximum entries in session {sesh} = {maxentries[sesh]}</p>")
 
 @app.route("/stats")
 def dumpStats():
@@ -133,14 +133,14 @@ def dumpStats():
 def resetStats():
   stats = dumpStats()
 
-  global last_stats,npublishes,nlookups,lookup_time,publish_time,maxpartitions,maxentries
+  global last_stats,npublishes,nlookups,lookup_time,publish_time,maxsessions,maxentries
 
   last_stats=datetime.now()
   npublishes=0
   nlookups=0
   lookup_time=timedelta(0)
   publish_time=timedelta()
-  maxpartitions=0
+  maxsessions=0
   maxentries={}
 
   return stats
@@ -148,36 +148,36 @@ def resetStats():
 @app.route("/resetService")
 def reset():
 
-  global partitions
-  partitions={}
+  global sessions
+  sessions={}
   return resetStats()
 
 
 @app.route("/publish",methods=['POST'])
 def publish():
   #  Store multiple connection ids and corresponding uris in a
-  #  dictionary associated with the appropriate partition.
+  #  dictionary associated with the appropriate session.
   timestamp=datetime.now()
   js=json.loads(request.data)
 
   log.debug(f"{js=}")
-  part=js['partition']
+  sesh=js['partition']
 
   log.info(
-    f"{len(js['connections'])} connections in partition {part} from {request.remote_addr} uri={js['connections'][0]['uri']}..."
+    f"{len(js['connections'])} connections in session {sesh} from {request.remote_addr} uri={js['connections'][0]['uri']}..."
   )
 
-  partlock.acquire()
-  if part in partitions:
-    store=partitions[part]
+  seshlock.acquire()
+  if sesh in sessions:
+    store=sessions[sesh]
   else:
     store={}
-    partitions[part]=store
-    global maxpartitions
-    if len(partitions)>maxpartitions:
-      maxpartitions=len(partitions)
-    if part not in maxentries:
-      maxentries[part]=0
+    sessions[sesh]=store
+    global maxsessions
+    if len(sessions)>maxsessions:
+      maxsessions=len(sessions)
+    if sesh not in maxentries:
+      maxentries[sesh]=0
 
   Connection=namedtuple(
     'Connection',['uri','data_type','capacity','connection_type','time'])
@@ -206,10 +206,10 @@ def publish():
   publish_time+=elapsed
   npublishes+=1
 
-  if len(store)>maxentries[part]:
-    maxentries[part]=len(store)
+  if len(store)>maxentries[sesh]:
+    maxentries[sesh]=len(store)
 
-  partlock.release()
+  seshlock.release()
   return 'OK'
 
 @app.route("/retract-session",methods=['POST'])
@@ -223,14 +223,14 @@ def retract_session():
   if 'partition' not in js:
     abort(400)
 
-  part=js['partition']
-  partlock.acquire()
+  sesh=js['partition']
+  seshlock.acquire()
 
-  if part in partitions:
-    partitions.pop(part)
-    partlock.release()
+  if sesh in sessions:
+    sessions.pop(sesh)
+    seshlock.release()
     return 'OK'
-  partlock.release()
+  seshlock.release()
   abort(404)
 
 
@@ -250,13 +250,13 @@ def retract():
 
   js=json.loads(request.data)
   good=True
-  part=js['partition']
-  partlock.acquire()
-  if part not in partitions:
-    partlock.release()
-    return make_response(f"Partition {part} not found", 404)
+  sesh=js['partition']
+  seshlock.acquire()
+  if sesh not in sessions:
+    seshlock.release()
+    return make_response(f"Session {sesh} not found", 404)
 
-  store=partitions[part]
+  store=sessions[sesh]
   if 'connections' not in js:
     abort(400)
   for con in js['connections']:
@@ -267,16 +267,16 @@ def retract():
       log.info(f"Could not find connection_id <{id}>")
       good=False
   if len(store)==0:
-    # We've deleted the last entry in this partition so delete the
-    # partition as well
-    partitions.pop(part)
-  partlock.release()
+    # We've deleted the last entry in this session so delete the
+    # session as well
+    sessions.pop(sesh)
+  seshlock.release()
   if good:
     return 'OK'
   abort(404)
 
-@app.route("/getconnection/<part>",methods=['POST','GET'])
-def get_connection(part):
+@app.route("/getconnection/<sesh>",methods=['POST','GET'])
+def get_connection(sesh):
   if len(request.data) == 0:
     abort(400)
 
@@ -295,17 +295,17 @@ def get_connection(part):
     result=[]
     regex=re.compile(js['uid_regex'])
     dt=js['data_type']
-    partlock.acquire()
+    seshlock.acquire()
 
-    if part in partitions:
-      store=partitions[part]
+    if sesh in sessions:
+      store=sessions[sesh]
       matched=[]
       for uid,con in store.items():
         if regex.fullmatch(uid) and con.data_type==dt and now-con.time<entry_ttl:
           matched.append((uid,con))
-      partlock.release()
+      seshlock.release()
       # We should now be able to construct JSON string while other threads
-      # have access to the partition dict
+      # have access to the session dict
       for uid,con in matched:
         result.append('{'
                       f'"uid":"{uid}",'
@@ -327,8 +327,8 @@ def get_connection(part):
 
       return "["+",".join(result)+"]"
 
-    partlock.release()
-    log.info(f"Partition {part} not found")
+    seshlock.release()
+    log.info(f"Session {sesh} not found")
     abort(404)
   else:
     abort(400)

--- a/tests/test_connectivityservice.py
+++ b/tests/test_connectivityservice.py
@@ -34,7 +34,7 @@ con = json.loads("""{
      "uri":"tcp://192.168.1.100:1235"
     }
    ],
-   "partition":"ccTest"
+   "session":"ccTest"
   }""")
 
 
@@ -46,6 +46,23 @@ def test_noconnection(client):
 def test_publish(client):
   resp = client.post("/publish", json=con)
   assert resp.status_code == 200
+
+
+def test_publish_with_partition_still_works(client):
+  partition_con = {
+    "connections": con["connections"],
+    "partition": "ccPartitionCompat",
+  }
+
+  resp = client.post("/publish", json=partition_con)
+  assert resp.status_code == 200
+
+  query = {"uid_regex": "DRO.*", "data_type": "TPSet"}
+  resp = client.post("/getconnection/ccPartitionCompat", json=query)
+  assert resp.status_code == 200
+
+  rjson = json.loads(resp.data)
+  assert len(rjson) == 2
 
 def test_lookup(client):
   query = json.loads("""{"uid_regex":"DRO.*", "data_type":"TPSet"}""")
@@ -68,7 +85,7 @@ def test_retract(client):
   resp = client.post("/retract")
   assert resp.status_code == 400
 
-  retraction = json.loads("""{"partition":"ccTest",
+  retraction = json.loads("""{"session":"ccTest",
     "connections":[{"connection_id":"DRO-000-tp_to_trigger"},
                    {"connection_id":"DRO-001-tp_to_trigger"}]
   }""")
@@ -84,14 +101,14 @@ def test_retract(client):
   assert resp.status_code == 404
 
 
-def test_retract_partition(client):
+def test_retract_session(client):
   resp = client.post("/publish", json=con)
   assert resp.status_code == 200
 
   resp = client.post("/retract-session")
   assert resp.status_code == 400
 
-  retraction = json.loads("""{"partition":"ccTest"}""")
+  retraction = json.loads("""{"session":"ccTest"}""")
   resp = client.post("/retract-session", json=retraction)
   assert resp.status_code == 200
 

--- a/tests/test_connectivityservice.py
+++ b/tests/test_connectivityservice.py
@@ -88,15 +88,15 @@ def test_retract_partition(client):
   resp = client.post("/publish", json=con)
   assert resp.status_code == 200
 
-  resp = client.post("/retract-partition")
+  resp = client.post("/retract-session")
   assert resp.status_code == 400
 
   retraction = json.loads("""{"partition":"ccTest"}""")
-  resp = client.post("/retract-partition", json=retraction)
+  resp = client.post("/retract-session", json=retraction)
   assert resp.status_code == 200
 
   # Second time should fail
-  resp = client.post("/retract-partition", json=retraction)
+  resp = client.post("/retract-session", json=retraction)
   assert resp.status_code == 404
 
 


### PR DESCRIPTION
# Description

Fixes #32 

Needs to go in with [the associated change in drunc#892](https://github.com/DUNE-DAQ/drunc/pull/892)

Maintains backwards compatibility with the old 'partition' in two ways:
- the retract-partition function still exists, redirects to retract-session, logs a warning just in case
- the payload first checks for session, and then partition, raises if nothing is found. Also raises an error if _both_ session and partition are defined in the payload. 


Pytest added to check for backwards compatibility

## TODO
- [ ] Check on the full integ test 
- [ ] Get pawel's review first
- [ ] Tell Kurt about this :) 


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [x] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [x] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

Nothing special, just clone this repo and the PR for drunc linked above and run a simple drunc session on yourself and see if the connsvc works just fine. 

## Further checks

- [x] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

