### PR TITLE
before_first_request is deprecated, use app_context() instead

### DIFF
--- a/src/connectivityserver/connectionflask.py
+++ b/src/connectivityserver/connectionflask.py
@@ -59,12 +59,11 @@ maxpartitions = 0
 maxentries = {}
 
 app = Flask(__name__)
+global appstarted
 appstarted = False
 
 
-@app.before_first_request
-def mark_started():
-    global appstarted
+with app.app_context():
     appstarted = True
 
 


### PR DESCRIPTION
# Description

before_first_request is deprecated in Flask 2.2+. Advice in https://stackoverflow.com/questions/73570041/flask-deprecated-before-first-request-how-to-update is to use `with app.app_context():` instead.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

